### PR TITLE
Add support for Unix domain sockets in step-sds init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.12.x
+- 1.13.x
 addons:
   apt:
     packages:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  branch = "master"
+  digest = "1:df416aef14f1103aea76c44be36073f8765565aba08e8acb37cde8c15f28bf33"
+  name = "github.com/AndreasBriese/bbloom"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "46b345b51c9667fcbaad862a370d73bd7aa802b6"
+
+[[projects]]
   digest = "1:9afc639ef88d907f2e87ab68cbc63117b88d0d84238fd6b08224515d00a8136a"
   name = "github.com/alecthomas/gometalinter"
   packages = ["."]
@@ -37,6 +45,29 @@
   version = "v0.3.4"
 
 [[projects]]
+  digest = "1:21ac9938fb1098b3a7b0dd909fb30878d33231177fac11a2821114eb9c1088ff"
+  name = "github.com/dgraph-io/badger"
+  packages = [
+    ".",
+    "options",
+    "protos",
+    "skl",
+    "table",
+    "y",
+  ]
+  pruneopts = "UT"
+  revision = "391b6d3b93e6014fe8c2971fcc0c1266e47dbbd9"
+  version = "v1.5.3"
+
+[[projects]]
+  branch = "master"
+  digest = "1:6e8109ce247a59ab1eeb5330166c12735f6590de99c9647b6162d11518d32c9a"
+  name = "github.com/dgryski/go-farm"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6a90982ecee230ff6cba02d5bd386acc030be9d3"
+
+[[projects]]
   digest = "1:47d2eab2d709f99ed4eb0c4994c7d8cdf4e0dc1627cbced538de02c40d7cbb46"
   name = "github.com/envoyproxy/go-control-plane"
   packages = [
@@ -61,6 +92,14 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "d0891661345200ebf8b816cc7de785e9bd570647"
+
+[[projects]]
+  digest = "1:ec6f9bf5e274c833c911923c9193867f3f18788c461f76f05f62bb1510e0ae65"
+  name = "github.com/go-sql-driver/mysql"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "72cd26f257d44c1114970e19afddcd812016007e"
+  version = "v1.4.1"
 
 [[projects]]
   digest = "1:b6866b08184222995bf9347b648e11dc252317b809ee9f72c8724c07a016b303"
@@ -195,6 +234,28 @@
   version = "v0.0.7"
 
 [[projects]]
+  branch = "master"
+  digest = "1:1c0746cc5facc7d8d3b77e4035d0df68fe72e01bd9833d9a566780a54c4be43a"
+  name = "github.com/mmcloughlin/avo"
+  packages = [
+    "attr",
+    "build",
+    "buildtags",
+    "gotypes",
+    "internal/prnt",
+    "internal/stack",
+    "ir",
+    "operand",
+    "pass",
+    "printer",
+    "reg",
+    "src",
+    "x86",
+  ]
+  pruneopts = "UT"
+  revision = "c8004ba627cacd7bab12cf9243c2f14d89c71cbe"
+
+[[projects]]
   digest = "1:266d082179f3a29a4bdcf1dcc49d4a304f5c7107e65bd22d1fecacf45f1ac348"
   name = "github.com/newrelic/go-agent"
   packages = [
@@ -281,9 +342,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:be6302e3c9152c3041274d363b8e77ef0b1c45919edaefbb06a2df1fc20ba534"
+  digest = "1:5dfecde4b625d8a37f04ae8720c5f87cce5bb8a6dc74fe5b019699600f6f0eaa"
   name = "github.com/smallstep/certificates"
   packages = [
+    "acme",
+    "acme/api",
     "api",
     "authority",
     "authority/provisioner",
@@ -294,11 +357,11 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "6af1e95c5b6b0a4f7a73d6ac1bdeff3a748932c7"
+  revision = "81093c3080eb068cc186a49bcea38db1c3a98ddb"
 
 [[projects]]
   branch = "master"
-  digest = "1:934d12f63ad5b7ed8a5c855d4f21e8aceb175e9b859f3ecad07f8b6a2080a545"
+  digest = "1:680c1bbd35585ba3020f00ef806eed6e5bfae53c4063e387b30d81c26309ca3e"
   name = "github.com/smallstep/cli"
   packages = [
     "command",
@@ -321,15 +384,21 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "499ccacece4cd3820208667c041e76aaa2d01bff"
+  revision = "662cb15c611f5c8142917233580f18c2ca6a080d"
 
 [[projects]]
   branch = "master"
-  digest = "1:fd8d9eb07509d8ef47fc82c99646f0b2203b2ba3c240ba77d8c457bb6109836d"
+  digest = "1:9c1b7052fa8f2c918efd60ed5ae3c70ccbba08967c58ec71067535449a3ba220"
   name = "github.com/smallstep/nosql"
-  packages = ["."]
+  packages = [
+    ".",
+    "badger",
+    "bolt",
+    "database",
+    "mysql",
+  ]
   pruneopts = "UT"
-  revision = "d8f68d14f9ae04e0991dce06b44768f2d38dccf8"
+  revision = "a0934e12468769d8cbede3ed316c47a4b88de4ca"
 
 [[projects]]
   branch = "master"
@@ -357,15 +426,20 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d270d7c7614032c6751cb02fca0a3aba9d2252ae7f2b475e8e0226945bd94f9f"
+  digest = "1:a4751364f82a8b5b06017d062439f218cf0cf212b0433339bafa53438737ceb7"
   name = "golang.org/x/crypto"
   packages = [
     "cryptobyte",
     "cryptobyte/asn1",
+    "curve25519",
     "ed25519",
     "ed25519/internal/edwards25519",
+    "internal/chacha20",
+    "internal/subtle",
     "ocsp",
     "pbkdf2",
+    "poly1305",
+    "ssh",
   ]
   pruneopts = "UT"
   revision = "a5d413f7728c81fb97d96a2b722368945f651e78"
@@ -398,9 +472,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e18c1645adfe83d66f80d3676040e478895669f9456ca8bafa6a7290656c1b48"
+  digest = "1:17d4aa98cea38b7de4fe214aa57f8b1a39c85b45d8cdc6e9b37d575f9cf5f23d"
   name = "golang.org/x/sys"
-  packages = ["unix"]
+  packages = [
+    "cpu",
+    "unix",
+  ]
   pruneopts = "UT"
   revision = "81d4e9dc473e5e8c933f2aaeba2a3d81efb9aed2"
 
@@ -429,16 +506,29 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a45ec3bb7c73e52430410dff3e0a5534ce518f72a8eb4355bc8502c546b91ecc"
+  digest = "1:f7eb066115bc018abc31a7bba8d94ec5d728cf6bdcc2a14c30e05b686daf73c7"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "go/gcexportdata",
     "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
     "go/types/typeutil",
+    "internal/fastwalk",
+    "internal/gopathwalk",
+    "internal/semver",
   ]
   pruneopts = "UT"
   revision = "8a44e74612bcf51f0d4407df3d3a8377cb99c2d8"
+
+[[projects]]
+  digest = "1:c25289f43ac4a68d88b02245742347c94f1e108c534dda442188015ff80669b3"
+  name = "google.golang.org/appengine"
+  packages = ["cloudsql"]
+  pruneopts = "UT"
+  revision = "5f2a59506353b8d5ba8cbbcd9f3c1f41f1eaf079"
+  version = "v1.6.2"
 
 [[projects]]
   branch = "master"

--- a/sds/service.go
+++ b/sds/service.go
@@ -55,8 +55,8 @@ type Service struct {
 func New(c Config) (*Service, error) {
 	p, err := ca.NewProvisioner(
 		c.Provisioner.Issuer, c.Provisioner.KeyID,
-		c.Provisioner.CaURL, c.Provisioner.CaRoot,
-		[]byte(c.Provisioner.Password))
+		c.Provisioner.CaURL, []byte(c.Provisioner.Password),
+		ca.WithRootFile(c.Provisioner.CaRoot))
 	if err != nil {
 		return nil, err
 	}

--- a/sds/utils_test.go
+++ b/sds/utils_test.go
@@ -409,7 +409,7 @@ func readJSON(w http.ResponseWriter, r *http.Request, v interface{}) {
 }
 
 func caProvisioner(srv *httptest.Server) *ca.Provisioner {
-	p, err := ca.NewProvisioner("sds@smallstep.com", "oA1x2nV3yClaf2kQdPOJ_LEzTGw5ow4r2A5SWl3MfMg", srv.URL, "testdata/root_ca.crt", []byte("password"))
+	p, err := ca.NewProvisioner("sds@smallstep.com", "oA1x2nV3yClaf2kQdPOJ_LEzTGw5ow4r2A5SWl3MfMg", srv.URL, []byte("password"), ca.WithRootFile("testdata/root_ca.crt"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Description
This PR adds support for initializing the configuration file sds.json with Unix domain sockets. It also updates the step dependencies using the new API for ca.Provisioner.