### PR TITLE
Pin envoy versions in examples to v1.9.1

### DIFF
--- a/examples/docker/envoy-sds/Dockerfile
+++ b/examples/docker/envoy-sds/Dockerfile
@@ -1,5 +1,5 @@
 FROM smallstep/step-sds:latest AS sds
-FROM envoyproxy/envoy-alpine
+FROM envoyproxy/envoy-alpine:v1.9.1
 
 RUN apk update
 RUN apk add python3

--- a/examples/docker/envoy/Dockerfile
+++ b/examples/docker/envoy/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy-alpine
+FROM envoyproxy/envoy-alpine:v1.9.1
 
 RUN apk update
 RUN apk add python3


### PR DESCRIPTION
There is no `latest` tag any more, and the Envoy configuration in
the examples is not compatible with the latest Envoy version
(v1.21.2) in any case.

Other, later, versions of Envoy probably also work but given the
timestamps on the file the latest version available at the time
the example was written was either v1.9.1 or v1.10.0, I have
verified v1.9.1 works.