### PR TITLE
Ignore rand.Seed deprecation

### DIFF
--- a/cmd/step-sds/main.go
+++ b/cmd/step-sds/main.go
@@ -81,6 +81,7 @@ This documentation is available online at https://github.com/smallstep/step-sds
 func init() {
 	step.Set("Smallstep SDS", Version, BuildTime)
 	sds.Identifier = step.Version()
+	//nolint:staticcheck // deprecated in Go 1.20 - leaving because we support latest 2 versions of golang
 	rand.Seed(time.Now().UnixNano())
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smallstep/step-sds
 
-go 1.18
+go 1.19
 
 require (
 	github.com/envoyproxy/go-control-plane v0.11.0


### PR DESCRIPTION
- we will remove once we are no longer compiling and testing with go1.19

