### PR TITLE
Initialize step environment

### DIFF
--- a/cmd/step-sds/main.go
+++ b/cmd/step-sds/main.go
@@ -101,6 +101,12 @@ func panicHandler() {
 }
 
 func main() {
+	// initialize step environment.
+	if err := step.Init(); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
 	defer panicHandler()
 	// Override global framework components
 	cli.VersionPrinter = func(c *cli.Context) {

--- a/cmd/step-sds/main.go
+++ b/cmd/step-sds/main.go
@@ -101,7 +101,7 @@ func panicHandler() {
 }
 
 func main() {
-	// initialize step environment.
+	// Initialize step environment.
 	if err := step.Init(); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)


### PR DESCRIPTION
This commit initializes the step environment. With the update of go.step.sm/cli-utils to v0.8.0, the "STEPPATH" is automatically initialized when `step.BasePath()`, `step.Home()` or the functions that depend on them are called, e.g., `step.Path()`. But we can also initialize at the start of the app and fail if those are not properly initialized.